### PR TITLE
bump python to 3.5.5

### DIFF
--- a/recipes/python-3.5/build.sh
+++ b/recipes/python-3.5/build.sh
@@ -7,6 +7,7 @@ rm -rf Lib/test Lib/*/test
 rm -rf Lib/ensurepip
 
 ./configure --enable-shared --enable-ipv6 --with-ensurepip=no \
+    --enable-optimizations \
     --prefix=$PREFIX \
     --with-tcltk-includes="-I$PREFIX/include" \
     --with-tcltk-libs="-L$PREFIX/lib -ltcl8.6 -ltk8.6" \

--- a/recipes/python-3.5/meta.yaml
+++ b/recipes/python-3.5/meta.yaml
@@ -1,11 +1,13 @@
+{% set version = "3.5.5" %}
+
 package:
   name: python
-  version: 3.5.4
+  version: {{ version }}
 
 source:
-  fn: Python-3.5.4.tgz
-  url: https://www.python.org/ftp/python/3.5.4/Python-3.5.4.tgz
-  md5: 2ed4802b7a2a7e40d2e797272bf388ec
+  fn: Python-{{ version }}.tgz
+  url: https://www.python.org/ftp/python/{{ version }}/Python-{{ version }}.tgz
+  md5: 7c825b747d25c11e669e99b912398585
 
 build:
   number: 0

--- a/recipes/python-3.5/run_test.py
+++ b/recipes/python-3.5/run_test.py
@@ -103,5 +103,3 @@ if not (ppc64le or osx105):
 
 import ssl
 print('OPENSSL_VERSION:', ssl.OPENSSL_VERSION)
-if sys.platform != 'win32':
-    assert '1.0.2l' in ssl.OPENSSL_VERSION


### PR DESCRIPTION
Update python version to 3.5.5.
Optimizations enabled.
Removed test with hard-coded openssl version