### PR TITLE
Fix conda_default_channels

### DIFF
--- a/installer/Berryconda3/construct.yaml
+++ b/installer/Berryconda3/construct.yaml
@@ -5,7 +5,7 @@ channels:
   - http://conda.anaconda.org/rpi
   
 conda_default_channels: 
-  - rpi
+  - http://conda.anaconda.org/rpi
 
 license_file: ../installer_license.txt
 


### PR DESCRIPTION
It seems you need to specify the full url now.